### PR TITLE
Update caching techniques for Dart2JS

### DIFF
--- a/lib/dart/railtie.rb
+++ b/lib/dart/railtie.rb
@@ -15,7 +15,7 @@ module Dart
     initializer :assets do |app|
       hash = (Digest::MD5.new << Time.now.to_s).to_s
       Dart::DART2JS_OUT_DIR = app.root.join('tmp', 'cache', 'assets', 'development', 'dart', hash)
-      
+
       # precompile compatibility-script
       ::Rails.application.config.assets.precompile << 'dart.js'
 

--- a/lib/dart/sprockets/directive_processor_dart2js.rb
+++ b/lib/dart/sprockets/directive_processor_dart2js.rb
@@ -23,8 +23,8 @@ module Dart
 
     def ensure_directories_exist
       path = Dart::DART2JS_OUT_DIR
-      directories = path.sub(Rails.root.to_s + '/', '').split('/')
-      folder_path = Rails.root.to_s
+      directories = path.sub((::Rails.root.to_s + '/'), '').split('/')
+      folder_path = ::Rails.root.to_s
 
       directories.each do |directory|
         folder_path += '/' + directory


### PR DESCRIPTION
This pr does a few things:
- Instead of using timestamps, we use an MD5 hash of the current time.
- `puts` adds a new line to the end of the text already, but a new line was required at the beginning.
- Ensures that folders exist. Quite often, a `Error: FileSystemException: Cannot open file` if the folder didn't exist in the cache.
